### PR TITLE
Add the ability to get credentials for a specific named service instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,26 @@ Output:
 
 ### Getting credentials for a specific plan
 
-Get credentials that match an specific service plan.
+Get credentials that match a specific service plan.
 ```sh
 var vcapServices = require('vcap_services');
 var credentials = vcapServices.getCredentials('personality_insights', 'standard');
+console.log(credentials);
+```
+
+### Getting credentials for a specific intsance
+Get credentials that match a specific service instance (replace "YOUR NLC NAME" with the name of your service instance).
+```sh
+var vcapServices = require('vcap_services');
+var credentials = vcapServices.getCredentials('natural_language_classifier', null, 'YOUR NLC NAME');
+console.log(credentials);
+```
+
+### Getting credentials for a specific plan and intsance
+Get credentials that match a specific service plan and instance (replace "YOUR NLC NAME" with the name of your service instance).
+```sh
+var vcapServices = require('vcap_services');
+var credentials = vcapServices.getCredentials('natural_language_classifier', 'standard', 'YOUR NLC NAME');
 console.log(credentials);
 ```
 

--- a/index.js
+++ b/index.js
@@ -7,17 +7,18 @@
  * the service instance that match that plan or {} otherwise
  * @param  String name, service name
  * @param  String plan, service plan
+ * @param  String iname, instance name
  * @return {Object} the service credentials or {} if
  * name is not found in VCAP_SERVICES
  */
-module.exports.getCredentials = function(name, plan) {
+module.exports.getCredentials = function(name, plan, iname) {
   if (process.env.VCAP_SERVICES) {
     var services = JSON.parse(process.env.VCAP_SERVICES);
     for (var service_name in services) {
       if (service_name.indexOf(name) === 0) {
         for (var i = services[service_name].length - 1; i >= 0; i--) {
           var instance = services[service_name][i];
-          if (!plan || plan === instance.plan)
+          if ((!plan || plan === instance.plan) && (!iname || iname === instance.name))
             return instance.credentials || {};
         }
       }

--- a/test/test.parse.js
+++ b/test/test.parse.js
@@ -36,6 +36,15 @@ describe('vcap_services', function() {
         label: 'retrieve_and_rank',
         plan: 'standard',
         credentials: credentials
+      }],
+      natural_language_classifier: [{
+        name: 'NLC 1',
+        plan: 'standard',
+        credentials: credentials
+      },{
+        name: 'NLC 2',
+        plan: 'standard',
+        credentials: credentials
       }]
     });
   });
@@ -60,6 +69,19 @@ describe('vcap_services', function() {
     assert.deepEqual(credentials, vcapServices.getCredentials('personality_insights','standard'));
     assert.deepEqual({}, vcapServices.getCredentials('personality','beta'));
     assert.deepEqual({}, vcapServices.getCredentials('personality','foo'));
+  });
+
+  it('should return the last available credentials that match an instance name', function() {
+    assert.deepEqual(credentials, vcapServices.getCredentials('natural_language_classifier',null,'NLC 1'));
+    assert.deepEqual({}, vcapServices.getCredentials('natural_language_classifier',null,'NLC 3'));
+    assert.deepEqual({}, vcapServices.getCredentials('natural_language_classifier','foo','NLC 1'));
+    assert.deepEqual({}, vcapServices.getCredentials('natural_language_classifier','foo','NLC 3'));
+  });
+
+  it('should return the last available credentials that match a plan and an instance name', function() {
+    assert.deepEqual(credentials, vcapServices.getCredentials('natural_language_classifier','standard','NLC 1'));
+    assert.deepEqual({}, vcapServices.getCredentials('natural_language_classifier','foo','NLC 1'));
+    assert.deepEqual({}, vcapServices.getCredentials('natural_language_classifier','foo','NLC 3'));
   });
 
   it('should return {} when service plan not found', function() {


### PR DESCRIPTION
Hi German,

I've got two NLC classifiers for an App I'm writing and need to be able to pull out credentials for them by name as this is the only way they are distinguished in VCAP_SERVICES.  This PR adds the functionality I need and maintains backwards compatibility.  You can get my on ST or the ibm-watson Slack if you need to chat.

Cheers,
Graham